### PR TITLE
V0.5.2 directory fix

### DIFF
--- a/backend/nodes/image_iterator_nodes.py
+++ b/backend/nodes/image_iterator_nodes.py
@@ -26,7 +26,7 @@ class ImageFileIteratorPathNode(NodeBase):
         self.description = ""
         self.inputs = [IteratorInput()]
         self.outputs = ImReadNode().get_outputs()
-        self.outputs.insert(2, TextOutput("Relative Path"))
+        self.outputs.insert(2, TextOutput("Relative Path"))  # Add relative path to outputs outside ImReadNode
         self.icon = "MdSubdirectoryArrowRight"
         self.sub = "Iteration"
 
@@ -36,8 +36,10 @@ class ImageFileIteratorPathNode(NodeBase):
         imread = ImReadNode()
         imread_output = imread.run(directory)
 
+        # Get relative path from root directory passed by Iterator directory input
         rel_path = os.path.relpath(imread_output[1], root_dir)
 
+        # Set ImRead directory output to root/base directory and insert relative path into outputs
         imread_output[1] = root_dir
         imread_output.insert(2, rel_path)
 
@@ -74,7 +76,7 @@ class ImageFileIteratorNode(IteratorNodeBase):
         id="",
         parent_executor=None,
         percent=0,
-    ) -> any:
+    ) -> Any:
         logger.info(f"Iterating over images in directory: {directory}")
         logger.info(nodes)
 

--- a/backend/nodes/image_iterator_nodes.py
+++ b/backend/nodes/image_iterator_nodes.py
@@ -26,15 +26,22 @@ class ImageFileIteratorPathNode(NodeBase):
         self.description = ""
         self.inputs = [IteratorInput()]
         self.outputs = ImReadNode().get_outputs()
-
+        self.outputs.insert(2, TextOutput("Relative Path"))
         self.icon = "MdSubdirectoryArrowRight"
         self.sub = "Iteration"
 
         self.type = "iteratorHelper"
 
-    def run(self, directory: str = "") -> any:
+    def run(self, directory: str = "", root_dir: str = "") -> any:
         imread = ImReadNode()
-        return imread.run(directory)
+        imread_output = imread.run(directory)
+
+        rel_path = os.path.relpath(imread_output[1], root_dir)
+
+        imread_output[1] = root_dir
+        imread_output.insert(2, rel_path)
+
+        return imread_output
 
 
 @NodeFactory.register("Image", "Image File Iterator")
@@ -120,7 +127,7 @@ class ImageFileIteratorNode(IteratorNodeBase):
                     base, ext = os.path.splitext(filepath)
                     if ext.lower() in supported_filetypes:
                         # Replace the input filepath with the filepath from the loop
-                        nodes[img_path_node_id]["inputs"] = [filepath]
+                        nodes[img_path_node_id]["inputs"] = [filepath, directory]
                         executor = Executor(
                             nodes,
                             loop,

--- a/backend/nodes/image_nodes.py
+++ b/backend/nodes/image_nodes.py
@@ -135,7 +135,7 @@ class ImWriteNode(NodeBase):
             relative_path = '.'
 
         full_file = f"{filename}.{extension}"
-        if relative_path != '.':
+        if relative_path and relative_path != '.':
             base_directory = os.path.join(base_directory, relative_path)
         full_path = os.path.join(base_directory, full_file)
 

--- a/backend/nodes/image_nodes.py
+++ b/backend/nodes/image_nodes.py
@@ -42,11 +42,12 @@ class ImReadNode(NodeBase):
             # IntegerOutput("Width"),
             # IntegerOutput("Channels"),
             TextOutput("Image Name"),
+            DirectoryOutput()
         ]
         self.icon = "BsFillImageFill"
         self.sub = "Input & Output"
 
-    def run(self, path: str) -> np.ndarray:
+    def run(self, path: str) -> tuple[np.ndarray, str, str]:
         """Reads an image from the specified path and return it as a numpy array"""
 
         logger.info(f"Reading image from path: {path}")
@@ -96,8 +97,8 @@ class ImReadNode(NodeBase):
         c = img.shape[2] if img.ndim > 2 else 1
 
         # return img, h, w, c
-        basename = os.path.splitext(os.path.basename(path))[0]
-        return img, basename
+        dirname, basename = os.path.split(os.path.splitext(path)[0])
+        return img, basename, dirname
 
 
 @NodeFactory.register("Image", "Save Image")
@@ -110,7 +111,7 @@ class ImWriteNode(NodeBase):
         self.description = "Save image to file at a specified directory."
         self.inputs = [
             ImageInput(),
-            DirectoryInput(),
+            DirectoryInput(hasHandle=True),
             TextInput("Image Name"),
             ImageExtensionDropdown(),
         ]
@@ -128,6 +129,8 @@ class ImWriteNode(NodeBase):
 
         # Put image back in int range
         img = (np.clip(img, 0, 1) * 255).round().astype("uint8")
+
+        os.makedirs(directory, exist_ok=True)
 
         status = cv2.imwrite(fullPath, img)
 

--- a/backend/nodes/properties/inputs/file_inputs.py
+++ b/backend/nodes/properties/inputs/file_inputs.py
@@ -42,9 +42,9 @@ def TorchFileInput() -> Dict:
     return FileInput("pth", "Pretrained Model", None, ["pth", "pt"])
 
 
-def DirectoryInput() -> Dict:
+def DirectoryInput(hasHandle: bool = False) -> Dict:
     """Input for submitting a local directory"""
-    return FileInput("directory", "Directory", None, ["directory"])
+    return FileInput("directory", "Directory", None, ["directory"], hasHandle)
 
 
 def ImageExtensionDropdown() -> Dict:

--- a/backend/nodes/properties/inputs/file_inputs.py
+++ b/backend/nodes/properties/inputs/file_inputs.py
@@ -44,7 +44,7 @@ def TorchFileInput() -> Dict:
 
 def DirectoryInput(hasHandle: bool = False) -> Dict:
     """Input for submitting a local directory"""
-    return FileInput("directory", "Directory", None, ["directory"], hasHandle)
+    return FileInput("directory", "Base Directory", None, ["directory"], hasHandle)
 
 
 def ImageExtensionDropdown() -> Dict:

--- a/backend/nodes/properties/outputs/file_outputs.py
+++ b/backend/nodes/properties/outputs/file_outputs.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, List
 
 

--- a/backend/nodes/properties/outputs/file_outputs.py
+++ b/backend/nodes/properties/outputs/file_outputs.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, List
 
 
@@ -16,6 +17,12 @@ def ImageFileOutput(label: str = "image") -> Dict:
         label, "Image File", ["png", "jpg", "jpeg", "gif", "tiff", "webp"]
     )
 
+
+def DirectoryOutput(label: str = "directory") -> Dict:
+    """Output for saving to a directory"""
+    return FileOutput(
+        label, "Image Directory", ["directory"]
+    )
 
 def OnnxFileOutput() -> Dict:
     """Output for saving a .onnx file"""

--- a/backend/nodes/properties/outputs/file_outputs.py
+++ b/backend/nodes/properties/outputs/file_outputs.py
@@ -24,6 +24,7 @@ def DirectoryOutput(label: str = "directory") -> Dict:
         label, "Image Directory", ["directory"]
     )
 
+
 def OnnxFileOutput() -> Dict:
     """Output for saving a .onnx file"""
     return FileOutput("onnx", "ONNX Model", ["onnx"])

--- a/backend/nodes/utility_nodes.py
+++ b/backend/nodes/utility_nodes.py
@@ -85,6 +85,6 @@ class TextAppendNode(NodeBase):
         str2: str,
         str3: str = None,
         str4: str = None,
-    ) -> int:
+    ) -> str:
         strings = [x for x in [str1, str2, str3, str4] if x != "" and x is not None]
         return separator.join(strings)

--- a/backend/run.py
+++ b/backend/run.py
@@ -152,7 +152,7 @@ async def run(request: Request):
 def get_extra_data(category, node, node_output):
     if category == "Image":
         if node == "Load Image":
-            img, name = node_output
+            img, name, dirname = node_output
 
             if img.ndim == 2:
                 h, w, c = img.shape[:2], 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainner",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainner",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "GPLv3",
       "dependencies": {
         "@chakra-ui/icons": "^1.0.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainner",
   "productName": "chaiNNer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A flowchart based image processing GUI",
   "main": ".webpack/main",
   "scripts": {

--- a/src/components/inputs/DirectoryInput.jsx
+++ b/src/components/inputs/DirectoryInput.jsx
@@ -9,8 +9,9 @@ import { GlobalContext } from '../../helpers/GlobalNodeState.jsx';
 const DirectoryInput = memo(({
   label, id, index, isLocked,
 }) => {
-  const { useInputData } = useContext(GlobalContext);
+  const { useInputData, useNodeLock } = useContext(GlobalContext);
   const [directory, setDirectory] = useInputData(id, index);
+  const [, , isInputLocked] = useNodeLock(id, index);
 
   const onButtonClick = async () => {
     const { canceled, filePaths } = await ipcRenderer.invoke('dir-select', directory ?? '');
@@ -36,7 +37,7 @@ const DirectoryInput = memo(({
         draggable={false}
         cursor="pointer"
         className="nodrag"
-        disabled={isLocked}
+        disabled={isLocked || isInputLocked}
       />
     </InputGroup>
   );

--- a/src/helpers/checkNodeValidity.js
+++ b/src/helpers/checkNodeValidity.js
@@ -16,7 +16,7 @@ const checkNodeValidity = ({
   // Finds all empty inputs
   const emptyInputs = Object.entries(inputData)
     .filter(
-      ([key, value]) => Object.keys(nonOptionalInputs).includes(String(key))
+      ([key, value]) => !inputs[key].optional
     && (value === '' || value === undefined || value === null)
     && !edgeTargetIndexes.includes(String(key)),
     )

--- a/src/helpers/dependencies.js
+++ b/src/helpers/dependencies.js
@@ -4,11 +4,11 @@ export default (isNvidiaAvailable) => [
   {
     name: 'OpenCV',
     packageName: 'opencv-python',
-    version: '4.5.5.62',
+    version: '4.5.5.64',
   }, {
     name: 'NumPy',
     packageName: 'numpy',
-    version: '1.22.1',
+    version: '1.22.3',
   }, {
     name: 'PyTorch',
     packageName: 'torch',
@@ -18,10 +18,9 @@ export default (isNvidiaAvailable) => [
     name: 'NCNN',
     packageName: 'ncnn-vulkan',
     version: '2022.4.1',
-  },
-  {
+  }, {
     name: 'Pillow (PIL)',
     packageName: 'Pillow',
-    version: '9.0.1',
+    version: '9.1.0',
   },
 ];

--- a/src/helpers/migrations.js
+++ b/src/helpers/migrations.js
@@ -143,6 +143,43 @@ const toV05 = (data) => {
 };
 
 // ==============
+//    v0.5.2
+// ==============
+const toV052 = (data) => {
+  const newData = { ...data };
+  newData.nodes.forEach((node) => {
+    // Update any connections coming out of a Load Image or Load Image (Iterator)
+    if (['Load Image', 'Load Image (Iterator)'].includes(node.data.type)) {
+      const edges = newData.edges.filter((e) => e.source === node.id);
+      edges.forEach((edge) => {
+        const edgeIndex = edge.sourceHandle.slice(-2);
+        // Image Name node moves different amounts in different Load Image types
+        const newEdgeIndex = (node.data.type === 'Load Image') ? '2' : '3';
+        if (edgeIndex === '-1') {
+          edge.sourceHandle = edge.source.concat('-', newEdgeIndex);
+        }
+      });
+    }
+
+    // Update any connections and inputs to Save Image Node
+    if (node.data.type === 'Save Image') {
+      // Shift text input values >=2 down one place and set Relative Path to empty string
+      node.data.inputData[4] = node.data.inputData[3];
+      node.data.inputData[3] = node.data.inputData[2];
+      node.data.inputData[2] = '';
+      // Move Image Name connection if it exists
+      const edges = newData.edges.filter((e) => e.target === node.id);
+      edges.forEach((edge) => {
+        const edgeIndex = edge.targetHandle.slice(-2);
+        if (edgeIndex === '-2')
+          edge.targetHandle = edge.target.concat('-', '3');
+      });
+    }
+  });
+  return newData;
+};
+
+// ==============
 
 export const migrate = (_version, data) => {
   let convertedData = data;
@@ -162,6 +199,11 @@ export const migrate = (_version, data) => {
   // v0.3.x & v0.4.x to v0.5.0
   if (semver.lt(version, '0.5.0')) {
     convertedData = toV05(convertedData);
+  }
+
+  // v0.5.0 & v0.5.1 to v0.5.2
+  if (semver.lt(version, '0.5.2')) {
+    convertedData = toV052(convertedData);
   }
 
   return convertedData;


### PR DESCRIPTION
-Added Image Directory to Load Image and Load Image (Iterator)
-Added Relative Path to Load Image (Iterator) and Save Image
-Added DirectoryOutput
-Added handle and locking to DirectoryInput
-Fixed validation bug that could result in optional inputs being incorrectly checked for input
-Added 0.5.2 migration to update Load (both) and Save Image nodes
-Updated OpenCV, numpy, and Pillow dependency requirements
-Incremented version number